### PR TITLE
fix: return 404 instead of 500 for missing customer ID

### DIFF
--- a/pages/api/customers/[id].ts
+++ b/pages/api/customers/[id].ts
@@ -6,14 +6,16 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
 
   const customer = customers.find((c) => c.id === id);
 
-  // BUG (Issue 3): No null check — accessing properties on undefined
-  // throws a 500 instead of returning a 404.
+  if (!customer) {
+    return res.status(404).json({ error: "Customer not found" });
+  }
+
   res.status(200).json({
-    id: customer!.id,
-    name: customer!.name,
-    email: customer!.email,
-    tier: customer!.tier,
-    balance: customer!.balance,
-    createdAt: customer!.createdAt,
+    id: customer.id,
+    name: customer.name,
+    email: customer.email,
+    tier: customer.tier,
+    balance: customer.balance,
+    createdAt: customer.createdAt,
   });
 }

--- a/tests/customers-api.test.ts
+++ b/tests/customers-api.test.ts
@@ -1,0 +1,45 @@
+import handler from "../pages/api/customers/[id]";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+function createMockReqRes(id: string) {
+  const req = { query: { id } } as unknown as NextApiRequest;
+  const res = {
+    statusCode: 0,
+    body: null as unknown,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(data: unknown) {
+      this.body = data;
+      return this;
+    },
+  } as unknown as NextApiResponse & { statusCode: number; body: unknown };
+  return { req, res };
+}
+
+describe("GET /api/customers/[id]", () => {
+  it("returns 200 with customer data for a valid ID", () => {
+    const { req, res } = createMockReqRes("C001");
+    handler(req, res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({
+      id: "C001",
+      name: "Acme Financial Corp",
+    });
+  });
+
+  it("returns 404 with error message for an invalid ID", () => {
+    const { req, res } = createMockReqRes("INVALID");
+    handler(req, res);
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toEqual({ error: "Customer not found" });
+  });
+
+  it("returns 404 for an empty ID", () => {
+    const { req, res } = createMockReqRes("");
+    handler(req, res);
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toEqual({ error: "Customer not found" });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #5: Customer details API returns 500 for missing customer ID.

## Root Cause

`customers.find()` returns `undefined` when no customer matches the given ID. The handler used non-null assertions (`customer!.property`) to access properties, which throws a `TypeError: Cannot read properties of undefined` resulting in an unhandled 500 error.

## Fix

- Added a null check after `customers.find()` that returns `{ "error": "Customer not found" }` with HTTP 404 when the customer is not found
- Removed non-null assertions (`!`) since TypeScript can now narrow the type after the guard clause

## Regression Tests Added

- Valid ID (`C001`) → 200 with customer data
- Invalid ID (`INVALID`) → 404 with error message
- Empty ID (`""`) → 404 with error message

## Validation

- All existing tests pass
- New regression tests pass (3/3)

---

**Requested by:** @duan-daniel
**Link to Devin session:** https://app.devin.ai/sessions/3a5d0e9937564fbea518418139d1c632