### PR TITLE
Fix 404 error for customers not found

### DIFF
--- a/pages/api/customers/[id].ts
+++ b/pages/api/customers/[id].ts
@@ -3,9 +3,13 @@ import customers from "../../../data/customers.json";
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
   const { id } = req.query;
-
+  
   const customer = customers.find((c) => c.id === id);
-
+  if(!customer){
+    return res.status(404).json({
+      error : "Customer not found"
+    })
+  }
   // BUG (Issue 3): No null check — accessing properties on undefined
   // throws a 500 instead of returning a 404.
   res.status(200).json({


### PR DESCRIPTION
Changed in /api/customers/[id].ts to handle for the customers who are not found returning 404 instead of 500